### PR TITLE
feat: add possibility to listen to react model open/request close

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalCallback.kt
@@ -1,0 +1,8 @@
+package com.facebook.react.views.modal;
+
+import android.content.DialogInterface;
+
+public interface ModalCallback {
+  public fun onModalOpen(dialog: DialogInterface?, viewTag: Int): Void
+  public fun onModalRequestClose(dialog: DialogInterface?, viewTag: Int): Void
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalCallback.kt
@@ -3,6 +3,6 @@ package com.facebook.react.views.modal;
 import android.content.DialogInterface;
 
 public interface ModalCallback {
-  public fun onModalOpen(dialog: DialogInterface?, viewTag: Int): Void
-  public fun onModalRequestClose(dialog: DialogInterface?, viewTag: Int): Void
+  public fun onModalOpen(dialog: DialogInterface?, viewTag: Int)
+  public fun onModalRequestClose(dialog: DialogInterface?, viewTag: Int)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalEventManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalEventManager.kt
@@ -1,0 +1,24 @@
+import android.content.DialogInterface
+import com.facebook.react.views.modal.ModalCallback
+
+public object ModalEventManager {
+  private val listeners: MutableList<ModalCallback> = mutableListOf()
+
+  public fun addModalListener(listener: ModalCallback) {
+    listeners.add(listener)
+  }
+
+  public fun onModalOpen(dialog: DialogInterface?, viewTag: Int) {
+    for (listener in listeners) {
+        listener.onModalOpen(dialog, viewTag)
+    }
+  }
+
+  public fun onModalRequestClose(dialog: DialogInterface?, viewTag: Int) {
+    for (listener in listeners) {
+      listener.onModalOpen(dialog, viewTag)
+    }
+  }
+
+  public fun removeAllListeners() { listeners.clear() }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalEventManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalEventManager.kt
@@ -16,7 +16,7 @@ public object ModalEventManager {
 
   public fun onModalRequestClose(dialog: DialogInterface?, viewTag: Int) {
     for (listener in listeners) {
-      listener.onModalOpen(dialog, viewTag)
+      listener.onModalRequestClose(dialog, viewTag)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalEventManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalEventManager.kt
@@ -1,5 +1,6 @@
+package com.facebook.react.views.modal;
+
 import android.content.DialogInterface
-import com.facebook.react.views.modal.ModalCallback
 
 public object ModalEventManager {
   private val listeners: MutableList<ModalCallback> = mutableListOf()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.modal
 
-import ModalEventManager
 import android.content.DialogInterface.OnShowListener
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
@@ -149,8 +148,8 @@ public class ReactModalHostManager :
   public override fun getDelegate(): ViewManagerDelegate<ReactModalHostView> = delegate
 
 
-  public override fun initialize() {
-    super.initialize()
+  public override fun invalidate() {
+    super.invalidate()
     modalEventManager.removeAllListeners()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.modal
 
+import ModalEventManager
 import android.content.DialogInterface.OnShowListener
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
@@ -29,6 +30,8 @@ import com.facebook.react.views.modal.ReactModalHostView.OnRequestCloseListener
 public class ReactModalHostManager :
     ViewGroupManager<ReactModalHostView>(), ModalHostViewManagerInterface<ReactModalHostView> {
   private val delegate: ViewManagerDelegate<ReactModalHostView> = ModalHostViewManagerDelegate(this)
+
+  private val modalEventManager = ModalEventManager
 
   public override fun getName(): String = REACT_CLASS
 
@@ -100,10 +103,12 @@ public class ReactModalHostManager :
     val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)
     if (dispatcher != null) {
       view.onRequestCloseListener = OnRequestCloseListener {
+        modalEventManager.onModalRequestClose(it, view.id)
         dispatcher.dispatchEvent(
             RequestCloseEvent(UIManagerHelper.getSurfaceId(reactContext), view.id))
       }
       view.onShowListener = OnShowListener {
+        modalEventManager.onModalOpen(it, view.id)
         dispatcher.dispatchEvent(ShowEvent(UIManagerHelper.getSurfaceId(reactContext), view.id))
       }
       view.eventDispatcher = dispatcher
@@ -142,6 +147,12 @@ public class ReactModalHostManager :
   }
 
   public override fun getDelegate(): ViewManagerDelegate<ReactModalHostView> = delegate
+
+
+  public override fun initialize() {
+    super.initialize()
+    modalEventManager.removeAllListeners()
+  }
 
   public companion object {
     public const val REACT_CLASS: String = "RCTModalHostView"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

At Reanimated we currently facing an issue that we're not able to listing to keyboard height changes in modal. This is due to the fact that android dialogs are attached next to the view tree, so we need to start observing insets on them separately, thus we need to listen to dialog open. To my knowledge, currently, there is no way to detect/listen when modal (dialog) is opened in a way that we can have access to its window (which we need to observe insets). The only hack that I found is listening to all events and act on “showModal”, which seems like hacky approach. In this PR I added observer that would be notified by ReactModalHostManager and would allow to attach listeners in other places. With this change in other packages we could get an instance and listen for those events. That should allow us to fix https://github.com/software-mansion/react-native-reanimated/pull/5916 and may help with https://github.com/kirillzyusko/react-native-keyboard-controller/issues/369.

## Changelog:

[ANDROID] [ADDED] - Allow to listen to RN Modal events in native code.

## Test Plan:

Tested on clean project from `npx @react-native-community/cli@next init MyApp --version next --skip-install`, which installs RN: 0.75.0-rc.5.

Tested with following part added to MainApplication.kt onCreate:
Changes in RN Core as in the PR.

<details>
<summary>Part added to MainApplication.kt onCreate:</summary>

```
ModalEventManager.addModalListener(object: ModalCallback {
      override fun onModalOpen(dialog: DialogInterface?, viewTag: Int) {
        println("Open")
        (dialog as Dialog).setOnDismissListener({
          println("Close")
        })
      }

      override fun onModalRequestClose(dialog: DialogInterface?, viewTag: Int) {
        println("onRequestClose")
      }
    })
  }
```

</details>

<details>
<summary>App.ts</summary>

```jsx
import * as React from 'react';
import {
  TextInput,
  View,
  Button,
  Modal,
  SafeAreaView,
  StyleSheet,
} from 'react-native';

function MyModal({ visible, hide }) {
  const [isVisible, setIsVisible] = React.useState(false);

  return (
    <Modal transparent visible={visible} onDismiss={hide} onRequestClose={hide} onLayout={(layout) => console.log('layout', layout)}>
      <View style={styles.modalContainer}>
        <View style={styles.modalContent}>
          <Button onPress={hide} title="Close Modal" />
          <TextInput style={styles.textInput} placeholder="Inside a modal" />
          <Button onPress={() => setIsVisible(visible => !visible)} title="Toggle Component With Animated Keyboard" />
        </View>
      </View>
    </Modal>
  );
}

export default function EmptyExample() {
  const [visible, setVisible] = React.useState(false);

  return (
    <>
      <SafeAreaView style={styles.container}>
        <Button onPress={() => setVisible(true)} title="Open Modal" />
        <TextInput style={styles.textInput} placeholder="Outside a modal" />
      </SafeAreaView>
      <MyModal visible={visible} hide={() => setVisible(false)} />
    </>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'space-between',
    backgroundColor: '#ecf0f1',
    paddingHorizontal: 8,
    paddingBottom: 50,
    paddingTop: 8,
  },
  modalContainer: {
    ...StyleSheet.absoluteFillObject,
    flex: 1,
    justifyContent: 'center',
    backgroundColor: 'rgba(0,0,0,0.2)',
  },
  modalContent: {
    justifyContent: 'space-between',
    backgroundColor: 'white',
    borderRadius: 24,
    padding: 24,
    minHeight: 256,
  },
  textInput: {
    paddingHorizontal: 8,
    paddingVertical: 4,
    borderRadius: 8,
    backgroundColor: 'silver',
    fontSize: 18,
    textAlign: 'center',
  },
});
```

</details>

<video src="https://github.com/user-attachments/assets/e18e32b0-df95-4850-a02f-6f87d892fd8d" />
